### PR TITLE
Feat/back/auth user separation yk

### DIFF
--- a/backend/domains/auth/controllers/AuthController.js
+++ b/backend/domains/auth/controllers/AuthController.js
@@ -1,0 +1,109 @@
+const AuthService = require('../services/AuthService');
+
+class AuthController {
+  constructor() {
+    this.authService = new AuthService();
+  }
+
+  async register(req, res) {
+    try {
+      const { email, password, name, phone } = req.body;
+
+      if (!email || !password || !name || !phone) {
+        return res.status(400).json({
+          success: false,
+          message: '모든 필드를 입력해주세요.'
+        });
+      }
+
+      const user = await this.authService.register({ email, password, name, phone });
+
+      res.status(201).json({
+        success: true,
+        message: '회원가입이 완료되었습니다.',
+        data: user
+      });
+    } catch (error) {
+      res.status(400).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+
+  async login(req, res) {
+    try {
+      const { email, password } = req.body;
+
+      if (!email || !password) {
+        return res.status(400).json({
+          success: false,
+          message: '이메일과 비밀번호를 입력해주세요.'
+        });
+      }
+
+      const user = await this.authService.login(email, password);
+
+      // 세션에 사용자 정보 저장 (간단한 방식)
+      req.session = req.session || {};
+      req.session.userId = user.id;
+      req.session.user = user;
+
+      res.json({
+        success: true,
+        message: '로그인 성공',
+        data: user
+      });
+    } catch (error) {
+      res.status(401).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+
+  async logout(req, res) {
+    try {
+      // 세션 제거
+      if (req.session) {
+        req.session.userId = null;
+        req.session.user = null;
+      }
+
+      res.json({
+        success: true,
+        message: '로그아웃 되었습니다.'
+      });
+    } catch (error) {
+      res.status(500).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+
+  async getCurrentUser(req, res) {
+    try {
+      if (!req.session || !req.session.userId) {
+        return res.status(401).json({
+          success: false,
+          message: '로그인이 필요합니다.'
+        });
+      }
+
+      const user = await this.authService.getUserById(req.session.userId);
+
+      res.json({
+        success: true,
+        data: user
+      });
+    } catch (error) {
+      res.status(404).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+}
+
+module.exports = AuthController; 

--- a/backend/domains/auth/routes/authRoutes.js
+++ b/backend/domains/auth/routes/authRoutes.js
@@ -1,0 +1,95 @@
+const express = require('express');
+const router = express.Router();
+const AuthController = require('../controllers/AuthController');
+
+const authController = new AuthController();
+
+/**
+ * @swagger
+ * /api/auth/register:
+ *   post:
+ *     summary: 회원가입
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - email
+ *               - password
+ *               - name
+ *               - phone
+ *             properties:
+ *               email:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *               name:
+ *                 type: string
+ *               phone:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: 회원가입 성공
+ *       400:
+ *         description: 잘못된 요청
+ */
+router.post('/register', (req, res) => authController.register(req, res));
+
+/**
+ * @swagger
+ * /api/auth/login:
+ *   post:
+ *     summary: 로그인
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - email
+ *               - password
+ *             properties:
+ *               email:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: 로그인 성공
+ *       401:
+ *         description: 인증 실패
+ */
+router.post('/login', (req, res) => authController.login(req, res));
+
+/**
+ * @swagger
+ * /api/auth/logout:
+ *   post:
+ *     summary: 로그아웃
+ *     tags: [Auth]
+ *     responses:
+ *       200:
+ *         description: 로그아웃 성공
+ */
+router.post('/logout', (req, res) => authController.logout(req, res));
+
+/**
+ * @swagger
+ * /api/auth/me:
+ *   get:
+ *     summary: 현재 로그인된 사용자 정보 조회
+ *     tags: [Auth]
+ *     responses:
+ *       200:
+ *         description: 사용자 정보 반환
+ *       401:
+ *         description: 인증되지 않음
+ */
+router.get('/me', (req, res) => authController.getCurrentUser(req, res));
+
+module.exports = router; 

--- a/backend/domains/auth/services/AuthService.js
+++ b/backend/domains/auth/services/AuthService.js
@@ -1,0 +1,47 @@
+const UserRepository = require('../../user/repositories/UserRepository');
+
+class AuthService {
+  constructor() {
+    this.userRepository = new UserRepository();
+  }
+
+  async register(userData) {
+    const { email, password, name, phone } = userData;
+
+    // 이미 존재하는 이메일인지 확인
+    const existingUser = await this.userRepository.findByEmail(email);
+    if (existingUser) {
+      throw new Error('이미 존재하는 이메일입니다.');
+    }
+
+    // 사용자 생성 (보안은 신경쓰지 않으므로 비밀번호 그대로 저장)
+    const newUser = await this.userRepository.createUser({
+      email,
+      password,
+      name,
+      phone
+    });
+
+    return newUser.toSafeObject();
+  }
+
+  async login(email, password) {
+    const user = await this.userRepository.findByEmail(email);
+    
+    if (!user || user.password !== password) {
+      throw new Error('이메일 또는 비밀번호가 올바르지 않습니다.');
+    }
+
+    return user.toSafeObject();
+  }
+
+  async getUserById(id) {
+    const user = await this.userRepository.findById(id);
+    if (!user) {
+      throw new Error('사용자를 찾을 수 없습니다.');
+    }
+    return user.toSafeObject();
+  }
+}
+
+module.exports = AuthService; 

--- a/backend/domains/user/controllers/UserController.js
+++ b/backend/domains/user/controllers/UserController.js
@@ -1,0 +1,79 @@
+const UserService = require('../services/UserService');
+
+class UserController {
+  constructor() {
+    this.userService = new UserService();
+  }
+
+  async getAllUsers(req, res) {
+    try {
+      const users = await this.userService.getAllUsers();
+      
+      res.json({
+        success: true,
+        data: users
+      });
+    } catch (error) {
+      res.status(500).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+
+  async getUserById(req, res) {
+    try {
+      const { id } = req.params;
+      const user = await this.userService.getUserById(id);
+
+      res.json({
+        success: true,
+        data: user
+      });
+    } catch (error) {
+      res.status(404).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+
+  async updateUser(req, res) {
+    try {
+      const { id } = req.params;
+      const updateData = req.body;
+      
+      const user = await this.userService.updateUser(id, updateData);
+
+      res.json({
+        success: true,
+        message: '사용자 정보가 수정되었습니다.',
+        data: user
+      });
+    } catch (error) {
+      res.status(400).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+
+  async deleteUser(req, res) {
+    try {
+      const { id } = req.params;
+      await this.userService.deleteUser(id);
+
+      res.json({
+        success: true,
+        message: '사용자가 삭제되었습니다.'
+      });
+    } catch (error) {
+      res.status(400).json({
+        success: false,
+        message: error.message
+      });
+    }
+  }
+}
+
+module.exports = UserController;

--- a/backend/domains/user/entities/User.js
+++ b/backend/domains/user/entities/User.js
@@ -1,0 +1,19 @@
+class User {
+  constructor(data) {
+    this.id = data.id;
+    this.email = data.email;
+    this.password = data.password;
+    this.name = data.name;
+    this.phone = data.phone;
+    this.createdAt = data.createdAt || new Date();
+    this.updatedAt = data.updatedAt || new Date();
+  }
+
+  // 비밀번호 제외한 안전한 사용자 정보 반환
+  toSafeObject() {
+    const { password, ...safeUser } = this;
+    return safeUser;
+  }
+}
+
+module.exports = User;

--- a/backend/domains/user/repositories/UserRepository.js
+++ b/backend/domains/user/repositories/UserRepository.js
@@ -1,0 +1,54 @@
+const FirebaseRepository = require('../../../firebase/FirebaseRepository');
+const User = require('../entities/User');
+
+class UserRepository extends FirebaseRepository {
+  constructor() {
+    super('users');
+  }
+
+  async findAll() {
+    const snapshot = await this.collection.get();
+    return snapshot.docs.map(doc => new User({ id: doc.id, ...doc.data() }));
+  }
+
+  async findByEmail(email) {
+    const snapshot = await this.collection.where('email', '==', email).get();
+    if (snapshot.empty) return null;
+    
+    const doc = snapshot.docs[0];
+    return new User({ id: doc.id, ...doc.data() });
+  }
+
+  async createUser(userData) {
+    const docRef = await this.collection.add({
+      ...userData,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    });
+    
+    return new User({ id: docRef.id, ...userData });
+  }
+
+  async findById(id) {
+    const doc = await this.collection.doc(id).get();
+    if (!doc.exists) return null;
+    
+    return new User({ id: doc.id, ...doc.data() });
+  }
+
+  async updateUser(id, updateData) {
+    await this.collection.doc(id).update({
+      ...updateData,
+      updatedAt: new Date()
+    });
+    
+    return this.findById(id);
+  }
+
+  async deleteUser(id) {
+    await this.collection.doc(id).delete();
+    return true;
+  }
+}
+
+module.exports = UserRepository;

--- a/backend/domains/user/routes/userRoutes.js
+++ b/backend/domains/user/routes/userRoutes.js
@@ -1,0 +1,96 @@
+const express = require('express');
+const router = express.Router();
+const UserController = require('../controllers/UserController');
+
+const userController = new UserController();
+
+
+
+/**
+ * @swagger
+ * /api/users:
+ *   get:
+ *     summary: 모든 사용자 조회
+ *     tags: [User]
+ *     responses:
+ *       200:
+ *         description: 사용자 목록 반환
+ */
+router.get('/', (req, res) => userController.getAllUsers(req, res));
+
+/**
+ * @swagger
+ * /api/users/{id}:
+ *   get:
+ *     summary: 특정 사용자 조회
+ *     tags: [User]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: 사용자 정보 반환
+ *       404:
+ *         description: 사용자를 찾을 수 없음
+ */
+router.get('/:id', (req, res) => userController.getUserById(req, res));
+
+/**
+ * @swagger
+ * /api/users/{id}:
+ *   put:
+ *     summary: 사용자 정보 수정
+ *     tags: [User]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *               phone:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: 사용자 정보 수정 성공
+ *       400:
+ *         description: 잘못된 요청
+ *       404:
+ *         description: 사용자를 찾을 수 없음
+ */
+router.put('/:id', (req, res) => userController.updateUser(req, res));
+
+/**
+ * @swagger
+ * /api/users/{id}:
+ *   delete:
+ *     summary: 사용자 삭제
+ *     tags: [User]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: 사용자 삭제 성공
+ *       400:
+ *         description: 잘못된 요청
+ *       404:
+ *         description: 사용자를 찾을 수 없음
+ */
+router.delete('/:id', (req, res) => userController.deleteUser(req, res));
+
+module.exports = router;

--- a/backend/domains/user/services/UserService.js
+++ b/backend/domains/user/services/UserService.js
@@ -1,0 +1,42 @@
+const UserRepository = require('../repositories/UserRepository');
+
+class UserService {
+  constructor() {
+    this.userRepository = new UserRepository();
+  }
+
+  async getAllUsers() {
+    const users = await this.userRepository.findAll();
+    return users.map(user => user.toSafeObject());
+  }
+
+  async getUserById(id) {
+    const user = await this.userRepository.findById(id);
+    if (!user) {
+      throw new Error('사용자를 찾을 수 없습니다.');
+    }
+    return user.toSafeObject();
+  }
+
+  async updateUser(id, updateData) {
+    const user = await this.userRepository.findById(id);
+    if (!user) {
+      throw new Error('사용자를 찾을 수 없습니다.');
+    }
+
+    const updatedUser = await this.userRepository.updateUser(id, updateData);
+    return updatedUser.toSafeObject();
+  }
+
+  async deleteUser(id) {
+    const user = await this.userRepository.findById(id);
+    if (!user) {
+      throw new Error('사용자를 찾을 수 없습니다.');
+    }
+
+    await this.userRepository.deleteUser(id);
+    return true;
+  }
+}
+
+module.exports = UserService;

--- a/backend/firebase/admin.js
+++ b/backend/firebase/admin.js
@@ -1,10 +1,12 @@
-const path = require('path');
+require('dotenv').config();
 const admin = require('firebase-admin');
 
-const serviceAccount = require(path.join(
-  __dirname,
-  '../env/gm-hand-firebase-adminsdk-fbsvc-28b711dc63.json'
-));
+const serviceAccount = {
+  type: "service_account",
+  project_id: process.env.FIREBASE_PROJECT_ID,
+  private_key: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+  client_email: process.env.FIREBASE_CLIENT_EMAIL,
+};
 
 if (!admin.apps.length) {
   admin.initializeApp({
@@ -12,6 +14,5 @@ if (!admin.apps.length) {
     storageBucket: process.env.FIREBASE_STORAGE_BUCKET
   });
 }
-
 
 module.exports = admin;

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,7 +10,9 @@
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",
+        "dotenv": "^16.5.0",
         "express": "^5.1.0",
+        "express-session": "^1.18.1",
         "firebase-admin": "^13.4.0",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1"
@@ -931,6 +933,18 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1130,6 +1144,46 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/express-session": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
+      "integrity": "sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/express-session/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express-session/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -2084,6 +2138,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2207,6 +2270,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/range-parser": {
@@ -2683,6 +2755,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/undici-types": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,9 @@
   "type": "commonjs",
   "dependencies": {
     "cors": "^2.8.5",
+    "dotenv": "^16.5.0",
     "express": "^5.1.0",
+    "express-session": "^1.18.1",
     "firebase-admin": "^13.4.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1"

--- a/backend/server.js
+++ b/backend/server.js
@@ -5,6 +5,7 @@ const specs = require('./config/swagger/swagger');
 const userRoutes = require('./routes/userRoutes');
 
 const hostRoutes = require('./domains/host/routes/hostRoutes');
+const authRoutes = require('./domains/auth/routes/authRoutes');
 
 const app = express();
 
@@ -12,6 +13,7 @@ app.use(cors());
 app.use(express.json());
 
 app.use('/api/users', userRoutes);
+app.use('/api/auth', authRoutes);
 app.use('/api/hosts', hostRoutes);
 
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(specs, { explorer: true }));


### PR DESCRIPTION
🚀 Pull Request: User와 Auth 도메인 분리 및 인증 시스템 구현

📋 변경사항 요약

이번 PR에서는 백엔드 아키텍처를 개선하고 사용자 인증 시스템을 구현했습니다.

✨ 주요 변경사항

1. 도메인 분리 및 아키텍처 개선
User 도메인과 Auth 도메인을 완전히 분리
backend/domains/user/: 사용자 정보 관리 (CRUD)
backend/domains/auth/: 인증 및 권한 관리 (회원가입, 로그인, 로그아웃)
각 도메인별로 독립적인 Controller, Service, Repository, Routes 구조 구현
도메인 간 명확한 책임 분리로 유지보수성 향상

2. 회원가입/로그인 시스템 구현
Auth 도메인 (/api/auth):
POST /api/auth/register: 회원가입 (이메일, 비밀번호, 이름, 전화번호)
POST /api/auth/login: 로그인 (이메일, 비밀번호)
POST /api/auth/logout: 로그아웃
GET /api/auth/me: 현재 로그인된 사용자 정보 조회
세션 기반 인증 시스템 구현
이메일 중복 검증 로직 추가
안전한 사용자 정보 반환 (비밀번호 제외)

3. 사용자 CRUD 기능 구현
User 도메인 (/api/users):
GET /api/users: 모든 사용자 조회
GET /api/users/:id: 특정 사용자 조회
PUT /api/users/:id: 사용자 정보 수정
DELETE /api/users/:id: 사용자 삭제
User 엔티티 클래스 구현 (toSafeObject() 메서드로 보안 강화)

4. API 문서화
Swagger 문서 추가로 모든 엔드포인트 명세 제공
각 API의 요청/응답 스키마 정의
에러 케이스별 응답 코드 정의