### PR TITLE
feat(trip): hostId 검증 및 email 기반 여행 참가 기능 추가

### DIFF
--- a/backend/domains/trip/controllers/TripController.js
+++ b/backend/domains/trip/controllers/TripController.js
@@ -86,7 +86,8 @@ class TripController {
   async joinTrip(req, res, next) {
     try {
       const { id } = req.params;
-      const trip = await this.tripService.joinTrip(id);
+      const { email } = req.body;
+      const trip = await this.tripService.joinTrip(id, email);
       
       res.status(200).json({
         success: true,
@@ -100,7 +101,8 @@ class TripController {
   async leaveTrip(req, res, next) {
     try {
       const { id } = req.params;
-      const trip = await this.tripService.leaveTrip(id);
+      const { email } = req.body;
+      const trip = await this.tripService.leaveTrip(id, email);
       
       res.status(200).json({
         success: true,

--- a/backend/domains/trip/entities/Trip.js
+++ b/backend/domains/trip/entities/Trip.js
@@ -9,6 +9,7 @@ class Trip {
     endDate, 
     maxParticipants, 
     currentParticipants = 0,
+    participants = [],
     price, 
     included, 
     excluded,
@@ -26,6 +27,7 @@ class Trip {
     this.endDate = endDate;
     this.maxParticipants = maxParticipants;
     this.currentParticipants = currentParticipants;
+    this.participants = participants; // 참가자 email 배열
     this.price = price;
     this.included = included || [];
     this.excluded = excluded || [];

--- a/backend/domains/trip/repositories/TripRepository.js
+++ b/backend/domains/trip/repositories/TripRepository.js
@@ -19,11 +19,13 @@ class TripRepository extends FirebaseRepository {
     const snapshot = await this.collection.orderBy('createdAt', 'desc').get();
     return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
   }
+
   async findById(id) {
     const doc = await this.collection.doc(id).get();
     if (!doc.exists) return null;
     return { id: doc.id, ...doc.data() };
   }
+
   async findByHostId(hostId) {
     const snapshot = await this.collection
       .where('hostId', '==', hostId)
@@ -35,6 +37,14 @@ class TripRepository extends FirebaseRepository {
   async findByStatus(status) {
     const snapshot = await this.collection
       .where('status', '==', status)
+      .orderBy('createdAt', 'desc')
+      .get();
+    return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+  }
+
+  async findByLocation(region) {
+    const snapshot = await this.collection
+      .where('location.region', '==', region)
       .orderBy('createdAt', 'desc')
       .get();
     return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
@@ -56,6 +66,15 @@ class TripRepository extends FirebaseRepository {
 
    async updateParticipantCount(id, currentParticipants) {
     await this.collection.doc(id).update({
+      currentParticipants,
+      updatedAt: new Date()
+    });
+    return this.findById(id);
+  }
+
+  async updateParticipants(id, participants, currentParticipants) {
+    await this.collection.doc(id).update({
+      participants,
       currentParticipants,
       updatedAt: new Date()
     });

--- a/backend/domains/trip/routes/tripRoutes.js
+++ b/backend/domains/trip/routes/tripRoutes.js
@@ -30,7 +30,7 @@ const tripController = new TripController();
  *                 data:
  *                   $ref: '#/components/schemas/Trip'
  *       400:
- *         description: 잘못된 요청
+ *         description: 잘못된 요청 또는 존재하지 않는 호스트 ID
  */
 router.post('/', (req, res, next) => tripController.createTrip(req, res, next));
 
@@ -169,11 +169,24 @@ router.delete('/:id', (req, res, next) => tripController.deleteTrip(req, res, ne
  *         schema:
  *           type: string
  *         description: 여행 ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               email:
+ *                 type: string
+ *                 format: email
+ *                 description: 참가 신청할 사용자 이메일
+ *             required:
+ *               - email
  *     responses:
  *       200:
  *         description: 여행 참가 신청 성공
  *       400:
- *         description: 참가할 수 없는 여행 (마감, 취소됨 등)
+ *         description: 참가할 수 없는 여행 (마감, 취소됨 등) 또는 존재하지 않는 사용자 이메일
  *       404:
  *         description: 여행을 찾을 수 없음
  */
@@ -192,11 +205,24 @@ router.post('/:id/join', (req, res, next) => tripController.joinTrip(req, res, n
  *         schema:
  *           type: string
  *         description: 여행 ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               email:
+ *                 type: string
+ *                 format: email
+ *                 description: 참가 취소할 사용자 이메일
+ *             required:
+ *               - email
  *     responses:
  *       200:
  *         description: 여행 참가 취소 성공
  *       400:
- *         description: 참가자가 없음
+ *         description: 참가하지 않은 여행이거나 존재하지 않는 사용자 이메일
  *       404:
  *         description: 여행을 찾을 수 없음
  */

--- a/backend/domains/trip/services/TripService.js
+++ b/backend/domains/trip/services/TripService.js
@@ -1,12 +1,26 @@
 const TripRepository = require('../repositories/TripRepository');
+const HostRepository = require('../../host/repositories/HostRepository');
+const UserRepository = require('../../user/repositories/UserRepository');
 
 class TripService {
   constructor() {
     this.tripRepository = new TripRepository();
+    this.hostRepository = new HostRepository();
+    this.userRepository = new UserRepository();
   }
 
   async createTrip(tripData) {
     try {
+      // hostId 검증: Firebase에 실제 존재하는 host인지 확인
+      if (!tripData.hostId) {
+        throw new Error('호스트 ID는 필수입니다.');
+      }
+      
+      const hostExists = await this.hostRepository.findById(tripData.hostId);
+      if (!hostExists) {
+        throw new Error('존재하지 않는 호스트 ID입니다.');
+      }
+
       return await this.tripRepository.create(tripData);
     } catch (error) {
       throw new Error(`여행 생성 중 오류가 발생했습니다: ${error.message}`);
@@ -99,8 +113,18 @@ class TripService {
     }
   }
     
-    async joinTrip(tripId) {
+    async joinTrip(tripId, email) {
     try {
+      // Firestore users 컬렉션의 email 필드와 매칭 검증
+      if (!email) {
+        throw new Error('사용자 이메일은 필수입니다.');
+      }
+      
+      const userExists = await this.userRepository.findByEmail(email);
+      if (!userExists) {
+        throw new Error('등록되지 않은 사용자 이메일입니다.');
+      }
+
       const trip = await this.tripRepository.findById(tripId);
       if (!trip) {
         throw new Error('여행을 찾을 수 없습니다.');
@@ -114,26 +138,48 @@ class TripService {
         throw new Error('참가 인원이 마감되었습니다.');
       }
 
+      // 참가자 목록에 email 추가
+      const participants = trip.participants || [];
+      if (participants.includes(email)) {
+        throw new Error('이미 참가 신청한 여행입니다.');
+      }
+      
+      participants.push(email);
       const newParticipantCount = trip.currentParticipants + 1;
-      return await this.tripRepository.updateParticipantCount(tripId, newParticipantCount);
+      
+      return await this.tripRepository.updateParticipants(tripId, participants, newParticipantCount);
     } catch (error) {
       throw new Error(`여행 참가 중 오류가 발생했습니다: ${error.message}`);
     }
   }
 
-  async leaveTrip(tripId) {
+  async leaveTrip(tripId, email) {
     try {
+      // Firestore users 컬렉션의 email 필드와 매칭 검증
+      if (!email) {
+        throw new Error('사용자 이메일은 필수입니다.');
+      }
+
+      const userExists = await this.userRepository.findByEmail(email);
+      if (!userExists) {
+        throw new Error('등록되지 않은 사용자 이메일입니다.');
+      }
+
       const trip = await this.tripRepository.findById(tripId);
       if (!trip) {
         throw new Error('여행을 찾을 수 없습니다.');
       }
 
-      if (trip.currentParticipants <= 0) {
-        throw new Error('참가자가 없습니다.');
+      const participants = trip.participants || [];
+      if (!participants.includes(email)) {
+        throw new Error('참가하지 않은 여행입니다.');
       }
 
-      const newParticipantCount = trip.currentParticipants - 1;
-      return await this.tripRepository.updateParticipantCount(tripId, newParticipantCount);
+      // 참가자 목록에서 email 제거
+      const updatedParticipants = participants.filter(participantEmail => participantEmail !== email);
+      const newParticipantCount = Math.max(0, trip.currentParticipants - 1);
+      
+      return await this.tripRepository.updateParticipants(tripId, updatedParticipants, newParticipantCount);
     } catch (error) {
       throw new Error(`여행 참가 취소 중 오류가 발생했습니다: ${error.message}`);
     }


### PR DESCRIPTION
🚀 주요 변경사항

1. hostId 검증 강화
여행 등록 시 Firebase Firestore의 hosts 컬렉션에 실제 존재하는 hostId인지 검증
존재하지 않는 hostId로 여행 등록 불가능
데이터 무결성 보장
2. email 기반 여행 참가 시스템
여행 참가 신청/취소 시 email 필수 입력 (기존 userId에서 변경)
Firestore users 컬렉션의 email 필드와 매칭 검증
실제 email 형식이 아닌 문자열도 지원 (예: "string")
중복 참가 신청 방지
참가하지 않은 여행 취소 시도 방지
3. 데이터 구조 개선
Trip 엔티티에 participants 배열 추가 (참가자 email 목록)
참가자 관리를 위한 TripRepository.updateParticipants() 메서드 추가
지역별 여행 조회를 위한 findByLocation() 메서드 추가
4. Firebase 인덱스 최적화
Firestore 복합 인덱스 생성으로 성능 최적화
hostId + createdAt, status + createdAt, location.region + createdAt 인덱스 추가

🔧 기술적 변경사항

Backend
TripService: hostId/email 검증 로직 추가
TripController: joinTrip/leaveTrip에서 request body로 email 받도록 수정
TripRepository: participants 관리 및 지역별 조회 메서드 추가
Trip 엔티티: participants 필드 추가 (email 배열)

🛡️ 보안 및 데이터 무결성 강화
Firebase 실제 존재하는 host/user만 허용으로 데이터 무결성 보장
잘못된 참조로 인한 데이터 오류 방지

📚 문서 업데이트
Swagger API 문서에 email 파라미터 추가 및 스펙 업데이트
에러 응답 메시지 개선

✅ 테스트 확인사항
[x] hostId 검증으로 여행 등록 제한 확인
[x] email 검증으로 참가 신청/취소 제한 확인
[x] Firebase 인덱스 오류 해결 확인
[x] 여행 목록 조회 정상 동작 확인
[x] 중복 참가 방지 기능 확인

🔄 Breaking Changes
⚠️ 프론트엔드 수정 필요
여행 참가 신청/취소 API에 userId → email 파라미터 변경
프론트엔드에서 해당 API 호출 시 email 전달 필요
📋 후속 작업
[ ] 프론트엔드에서 email 파라미터 전달하도록 수정
[ ] 참가자 목록 조회 API 추가 고려
[ ] 이메일 형식 검증 추가 고려